### PR TITLE
Issue #4: Perform network requests asynchronously

### DIFF
--- a/UserListModel.cpp
+++ b/UserListModel.cpp
@@ -50,8 +50,9 @@ void UserListModel::fetchMore(const QModelIndex &parent)
 
     if(!isLoading) {
         isLoading = true;
-        QObject::connect(repo, &UserRepository::onUsersFetched, this, [=](QJsonArray usersJson) {
-            QObject::disconnect(repo, &UserRepository::onUsersFetched, 0, 0);
+        QObject *context = new QObject(this);
+        QObject::connect(repo, &UserRepository::onUsersFetched, context, [=](QJsonArray usersJson) {
+            context->deleteLater();
             QList<UserDisplayData*> *nextUsers = UserDisplayDataDeserializer::parse(usersJson);
             beginInsertRows(parent, insertFrom, insertCount - 1);
             userList.append(*nextUsers);

--- a/UserListModel.h
+++ b/UserListModel.h
@@ -3,7 +3,7 @@
 
 #include <QAbstractListModel>
 #include <UserDisplayData.h>
-#include <QCoreApplication>
+#include <UserRepository.h>
 
 class UserListModel : public QAbstractListModel
 {
@@ -13,7 +13,8 @@ public:
         UserRole = Qt::UserRole + 1,
     };
 
-    UserListModel(QCoreApplication *app, QObject *parent = nullptr);
+    explicit UserListModel(QObject *parent = nullptr);
+    ~UserListModel();
 
     QHash<int,QByteArray> roleNames() const override;
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
@@ -24,9 +25,10 @@ protected:
     void fetchMore(const QModelIndex &parent) override;
 
 private:
+    UserRepository *repo;
     QList<UserDisplayData*> userList;
-    QCoreApplication *app;
     static const int PAGE_SIZE = 50;
+    bool isLoading;
 };
 
 #endif // USERLISTMODEL_H

--- a/UserRepository.cpp
+++ b/UserRepository.cpp
@@ -18,7 +18,9 @@ void UserRepository::fetchUsers(int page, int size)
     QNetworkRequest request;
     request.setUrl(QUrl(endpoint));
     QNetworkReply *reply = netMgr->get(request);
-    QObject::connect(reply, &QNetworkReply::finished, this, [=](){
+    QObject *context = new QObject(this);
+    QObject::connect(reply, &QNetworkReply::finished, context, [=](){
+        context->deleteLater();
         if (reply->error()) {
             qDebug() << reply->errorString();
             return;

--- a/UserRepository.h
+++ b/UserRepository.h
@@ -1,14 +1,24 @@
 #ifndef USERREPOSITORY_H
 #define USERREPOSITORY_H
 
+#include <QObject>
 #include <QJsonArray>
 #include <QCoreApplication>
+#include <QNetworkAccessManager>
 
-class UserRepository
+class UserRepository : public QObject
 {
+    Q_OBJECT
 public:
-    UserRepository();
-    QJsonArray fetchUsersBlocking(const QCoreApplication *app, int page, int size) const;
+    explicit UserRepository(QObject *parent = nullptr);
+    ~UserRepository();
+    void fetchUsers(int page, int size);
+
+signals:
+    void onUsersFetched(QJsonArray usersJson);
+
+private:
+    QNetworkAccessManager *netMgr;
 };
 
 


### PR DESCRIPTION
Instead of using a blocking call that waits for the request to finish, use the signals provided by the qt network apis, to be notified when a response is ready.

Use our own signal, for the repository to notify when it's fetched users.